### PR TITLE
fix for Character.hitArea

### DIFF
--- a/src/txt/Character.ts
+++ b/src/txt/Character.ts
@@ -84,7 +84,7 @@ module txt {
             this.measuredWidth = this.scaleX * this._glyph.offset * this._font.units;
             
             var ha = new createjs.Shape();
-            ha.graphics.drawRect( 0 , this._font.descent , this._glyph.offset * this._font.units , this._font.ascent - this._font.descent );
+            ha.graphics.beginFill('#000').drawRect( 0 , this._font.descent , this._glyph.offset * this._font.units , this._font.ascent - this._font.descent );
             this.hitArea = ha;
             
         }


### PR DESCRIPTION
Character.hitArea need to have a fill prior to drawRect() or the hit area has no affect.